### PR TITLE
Add xUnit tests for CustomerRepo with in-memory DB

### DIFF
--- a/BankingManagementSystem.sln
+++ b/BankingManagementSystem.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Interfaces", "Interfaces\In
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Repository", "Repository\Repository.csproj", "{0276E7CE-95A6-4C22-A1CB-3F21FBF9A56B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RepositoryTests", "RepositoryTests\RepositoryTests.csproj", "{B1D3BAA8-0E8D-4E03-9B21-A247C71F8C2F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,11 +29,15 @@ Global
 		{662DDA83-498E-4640-9D4B-831990BB3B27}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{662DDA83-498E-4640-9D4B-831990BB3B27}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{662DDA83-498E-4640-9D4B-831990BB3B27}.Release|Any CPU.Build.0 = Release|Any CPU
-		{0276E7CE-95A6-4C22-A1CB-3F21FBF9A56B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{0276E7CE-95A6-4C22-A1CB-3F21FBF9A56B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{0276E7CE-95A6-4C22-A1CB-3F21FBF9A56B}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{0276E7CE-95A6-4C22-A1CB-3F21FBF9A56B}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {0276E7CE-95A6-4C22-A1CB-3F21FBF9A56B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {0276E7CE-95A6-4C22-A1CB-3F21FBF9A56B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {0276E7CE-95A6-4C22-A1CB-3F21FBF9A56B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {0276E7CE-95A6-4C22-A1CB-3F21FBF9A56B}.Release|Any CPU.Build.0 = Release|Any CPU
+                {B1D3BAA8-0E8D-4E03-9B21-A247C71F8C2F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {B1D3BAA8-0E8D-4E03-9B21-A247C71F8C2F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {B1D3BAA8-0E8D-4E03-9B21-A247C71F8C2F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {B1D3BAA8-0E8D-4E03-9B21-A247C71F8C2F}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/Repository/CustomerRepo.cs
+++ b/Repository/CustomerRepo.cs
@@ -2,7 +2,7 @@
 using Interfaces;
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
+using System.Data;
 using System.Linq;
 using System.Text;
 
@@ -13,9 +13,13 @@ namespace Repository
     {
         DatabaseConnectionClass dcc;
 
-        public CustomerRepo()
+        public CustomerRepo() : this(new DatabaseConnectionClass())
         {
-            dcc = new DatabaseConnectionClass();
+        }
+
+        public CustomerRepo(DatabaseConnectionClass connection)
+        {
+            dcc = connection;
         }
 
         public bool InsertCustomer(Customer cust)
@@ -65,7 +69,7 @@ namespace Repository
             Customer cust = null;
             string query = "SELECT * from Customers WHERE custId = '" + custId + "'";
             dcc.ConnectWithDB();
-            SqlDataReader sdr = dcc.GetData(query);
+            IDataReader sdr = dcc.GetData(query);
 
             while (sdr.Read())
             {
@@ -84,7 +88,7 @@ namespace Repository
             List<Customer> listOfCustomer = new List<Customer>();
             string query = "SELECT * FROM Customers";
             dcc.ConnectWithDB();
-            SqlDataReader sdr = dcc.GetData(query);
+            IDataReader sdr = dcc.GetData(query);
 
             while (sdr.Read())
             {

--- a/Repository/DatabaseConnectionClass.cs
+++ b/Repository/DatabaseConnectionClass.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Data.SqlClient;
 using System.Linq;
 using System.Text;
@@ -17,23 +18,23 @@ namespace Repository
             myConnection = new SqlConnection(connectionString);
         }
 
-        public void ConnectWithDB()
+        public virtual void ConnectWithDB()
         {
             myConnection.Open();
         }
-        public void CloseConnection()
+        public virtual void CloseConnection()
         {
             myConnection.Close();
         }
 
-        public SqlDataReader GetData(string query)
+        public virtual IDataReader GetData(string query)
         {
             myCommand = new SqlCommand(query, myConnection);
             //SqlDataReader sdr = myCommand.ExecuteReader();
             //return sdr;
             return myCommand.ExecuteReader();
         }
-        public int ExecuteSQL(string query)
+        public virtual int ExecuteSQL(string query)
         {
             myCommand = new SqlCommand(query, myConnection);
             //int x= myCommand.ExecuteNonQuery();

--- a/Repository/EmployeeRepo.cs
+++ b/Repository/EmployeeRepo.cs
@@ -2,6 +2,7 @@
 using Interfaces;
 using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Data.SqlClient;
 using System.Linq;
 using System.Text;
@@ -67,7 +68,7 @@ namespace Repository
             Employee emp = null;
             string query = "SELECT * from Employees WHERE empId = '" + empId + "'";
             dcc.ConnectWithDB();
-            SqlDataReader sdr =  dcc.GetData(query);
+            IDataReader sdr =  dcc.GetData(query);
 
             while (sdr.Read())
             {
@@ -87,7 +88,7 @@ namespace Repository
             List<Employee> listOfEmployee = new List<Employee>();
             string query = "SELECT * FROM Employees";
             dcc.ConnectWithDB();
-            SqlDataReader sdr = dcc.GetData(query);
+            IDataReader sdr = dcc.GetData(query);
 
             while (sdr.Read())
             {

--- a/Repository/LoginRepo.cs
+++ b/Repository/LoginRepo.cs
@@ -2,6 +2,7 @@
 using Interfaces;
 using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Data.SqlClient;
 using System.Linq;
 using System.Text;
@@ -67,7 +68,7 @@ namespace Repository
             Login l = null;
             string query = "SELECT * from Login WHERE Id = '" + id + "' AND Password ='" + password + "'";
             dcc.ConnectWithDB();
-            SqlDataReader sdr = dcc.GetData(query);
+            IDataReader sdr = dcc.GetData(query);
 
             while (sdr.Read())
             {

--- a/RepositoryTests/CustomerRepoTests.cs
+++ b/RepositoryTests/CustomerRepoTests.cs
@@ -1,0 +1,37 @@
+using Entity;
+using Repository;
+using RepositoryTests.Mocks;
+using Xunit;
+
+namespace RepositoryTests
+{
+    public class CustomerRepoTests
+    {
+        [Fact]
+        public void InsertCustomer_ReturnsTrue_ForValidInput()
+        {
+            var db = new InMemoryDbConnection();
+            var repo = new CustomerRepo(db);
+            var cust = new Customer { CustId = "C1", Name = "Alice", PhnNumber = "0123" };
+
+            var result = repo.InsertCustomer(cust);
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void GetCustomer_ReturnsInsertedRecord()
+        {
+            var db = new InMemoryDbConnection();
+            var repo = new CustomerRepo(db);
+            var cust = new Customer { CustId = "C2", Name = "Bob", PhnNumber = "9876" };
+            repo.InsertCustomer(cust);
+
+            var loaded = repo.GetCustomer("C2");
+
+            Assert.NotNull(loaded);
+            Assert.Equal("Bob", loaded.Name);
+            Assert.Equal("9876", loaded.PhnNumber);
+        }
+    }
+}

--- a/RepositoryTests/Mocks/InMemoryDbConnection.cs
+++ b/RepositoryTests/Mocks/InMemoryDbConnection.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Text.RegularExpressions;
+using Entity;
+using Repository;
+
+namespace RepositoryTests.Mocks
+{
+    public class InMemoryDbConnection : DatabaseConnectionClass
+    {
+        private readonly Dictionary<string, Customer> _customers = new Dictionary<string, Customer>();
+
+        public override void ConnectWithDB() { }
+        public override void CloseConnection() { }
+
+        public override int ExecuteSQL(string query)
+        {
+            // Very naive parser for INSERT queries used in tests
+            var match = Regex.Matches(query, "'([^']*)'");
+            if (match.Count >= 3)
+            {
+                var id = match[0].Groups[1].Value;
+                var name = match[1].Groups[1].Value;
+                var phone = match[2].Groups[1].Value;
+                _customers[id] = new Customer { CustId = id, Name = name, PhnNumber = phone };
+                return 1;
+            }
+            return 0;
+        }
+
+        public override IDataReader GetData(string query)
+        {
+            var m = Regex.Match(query, "WHERE custId = '([^']*)'", RegexOptions.IgnoreCase);
+            if (m.Success && _customers.TryGetValue(m.Groups[1].Value, out var cust))
+            {
+                var table = new DataTable();
+                table.Columns.Add("CustId");
+                table.Columns.Add("Name");
+                table.Columns.Add("PhnNumber");
+                table.Rows.Add(cust.CustId, cust.Name, cust.PhnNumber);
+                return table.CreateDataReader();
+            }
+            return (new DataTable()).CreateDataReader();
+        }
+    }
+}

--- a/RepositoryTests/RepositoryTests.csproj
+++ b/RepositoryTests/RepositoryTests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Test.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Repository\Repository.csproj" />
+    <ProjectReference Include="..\Entity\Entity.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- enable overriding DB connection methods
- allow injecting `DatabaseConnectionClass` in `CustomerRepo`
- read data using `IDataReader` across repositories
- add new test project `RepositoryTests`
- implement in-memory DB stub and unit tests

## Testing
- `dotnet test RepositoryTests/RepositoryTests.csproj -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cac2c1d9c8331a747abc866510d2e